### PR TITLE
Request to enable support to mount a host directory to /var/lib/pgsql/9.4/data

### DIFF
--- a/postgis/Dockerfile
+++ b/postgis/Dockerfile
@@ -2,12 +2,17 @@
 ## Strabon semantic spatiotemporal RDF store
 ## http://strabon.di.uoa.gr
 #
-# Build: docker build -t postgres:9.4 .
-#   Run: docker run -it -P --name postgres postgres
+# Build: docker build -t strabon_postgis .
+#   Run: docker run --name strabon_postgis strabon_postgis
+#   or
+#   Run: docker run -p 5432:5432 -v /srv/postgis/data:/var/lib/pgsql/9.4/data --name strabon_postgis  panos/postgis
 #
 
 FROM centos:7
 MAINTAINER Panayiotis Vlantis <p.vlantis@di.uoa.gr>
+MAINTAINER Yiannis Mouchakis <gmouchakis@iit.demokritos.gr>
+MAINTAINER Konstantinos Mitrogeorgos <konmitr@iit.demokritos.gr>
+
 
 # Locale setting
 ENV LANG en_US.UTF-8
@@ -25,8 +30,9 @@ RUN yum -y install epel-release && \
 RUN sed -i 's/.*requiretty$/#Defaults requiretty/' /etc/sudoers
 
 # Copy database scripts
-COPY initdb setupdb /usr/local/bin/
+COPY initdb setupdb copy_postgres_data /usr/local/bin/
 RUN chmod +x /usr/local/bin/*db
+RUN chmod +x /usr/local/bin/copy_postgres_data
 RUN chown -v postgres.postgres /usr/local/bin/setupdb
 
 # Initialize database
@@ -41,20 +47,14 @@ RUN /usr/local/bin/setupdb
 
 # Allow remote connections to database
 RUN echo -e "host \t all \t all \t 0.0.0.0/0 \t md5" \
-    >> /var/lib/pgsql/9.4/data/pg_hba.conf
+    >> /var/lib/pgsql/9.4/data_temp/pg_hba.conf
 
 # listen_addresses controls which interfaces accept connections
 RUN echo "listen_addresses='*'" \
-         >> /var/lib/pgsql/9.4/data/postgresql.conf
+         >> /var/lib/pgsql/9.4/data_temp/postgresql.conf
 
 # PostgreSQL port
 EXPOSE 5432
 
-# PostgreSQL volume
-VOLUME ["/var/lib/pgsql/9.4/data"]
-
-# Command to run when starting the container
-CMD [ "/usr/pgsql-9.4/bin/postgres",   \
-      "-D", "/var/lib/pgsql/9.4/data", \
-      "-p", "5432"                     \
-    ]
+USER root
+CMD /usr/local/bin/copy_postgres_data && su - postgres -c "/usr/pgsql-9.4/bin/postgres -D /var/lib/pgsql/9.4/data -p 5432"

--- a/postgis/README.md
+++ b/postgis/README.md
@@ -15,6 +15,10 @@ The initdb script is used to initialize the PostgreSQL database system.
 2. Creates a PostGIS database template
 3. Create a spatially-enabled database named endpoint that will be used by Strabon
 
+#### copy_postgres_data
+The copy_postgres_data copies on docker run the postgres data from the temp postgres data directory to the /var/lib/pgsql/9.4/data directory. 
+This enables mounting a host directory to /var/lib/pgsql/9.4/data without losing the init data created from the initdb script.
+
 ## Usage
 ##### Create a container named postgis and publish 5432 to a random port
 
@@ -23,6 +27,10 @@ The initdb script is used to initialize the PostgreSQL database system.
 ##### Create a container named postgis and publish 5432 to port 5432 on host
 
     docker run -p 5432:5432 --name postgis panos/postgis
+    
+##### Create a container named postgis, publish 5432 to port 5432 on host and mount /srv/postgis/data to /var/lib/pgsql/9.4/data
+
+    docker run -p 5432:5432 -v /srv/postgis/data:/var/lib/pgsql/9.4/data --name postgis panos/postgis
 
 ##### Create a container named postgis and open a bash shell instead of starting the database.  
 

--- a/postgis/copy_postgres_data
+++ b/postgis/copy_postgres_data
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+PGDATA="/var/lib/pgsql/9.4/data/"
+export PGDATA
+
+if [ -f "$PGDATA/PG_VERSION" ]; then
+    echo "data directory is not empty, not moving postgres data."
+else
+    echo "moving postgres initial data"
+    chown postgres:postgres $PGDATA
+    chmod 700 $PGDATA
+    cp -pr /var/lib/pgsql/9.4/data_temp/* $PGDATA
+    #mv /var/lib/pgsql/9.4/data_temp/* $PGDATA
+    rm -rf /var/lib/pgsql/9.4/data_temp
+    echo "finished moving postgres data."
+fi
+
+exit 0


### PR DESCRIPTION
The init of postgres is done in a temp directory /var/lib/pgsql/9.4/data_temp. On docker run the files are copied from the temp directory to /var/lib/pgsql/9.4/data. This enables the option to mount a host directory to /var/lib/pgsql/9.4/data without losing data created before. Added proper instructions to README.
